### PR TITLE
Make SignOutModal a functional component

### DIFF
--- a/src/components/Modals/SignOutModal.jsx
+++ b/src/components/Modals/SignOutModal.jsx
@@ -1,50 +1,51 @@
-import React from 'react'
-import Modal from 'react-modal'
-import firebase from '../../config/firebase'
-import { connect } from 'react-redux'
-import { toggleSignOutModal, logInStateChange } from '../../actions/actionCreators'
+import React from 'react';
+import Modal from 'react-modal';
+import firebase from '../../config/firebase';
+import { connect } from 'react-redux';
+import { toggleSignOutModal, logInStateChange } from '../../actions/actionCreators';
 
-Modal.setAppElement('#root')
+Modal.setAppElement('#root');
 
-class SignOutModal extends React.Component {
-  signOut = () => {
-    firebase.auth().signOut()
-    localStorage.removeItem('userInfo')
-    this.props.dispatch(logInStateChange({ userUID: null, userLoggedIn: false }))
-    this.props.dispatch(toggleSignOutModal())
-  }
+const SignOutModal = ({
+  isOpen,
+  logInStateChange,
+  toggleSignOutModal,
+}) => {
+  const signOut = () => {
+    firebase.auth().signOut();
+    localStorage.removeItem('userInfo');
+    logInStateChange({ userUID: null, userLoggedIn: false });
+    toggleSignOutModal();
+  };
 
-  render () {
-    const { isOpen } = this.props
-    return (
-      <Modal
-        isOpen={isOpen}
-        onAfterOpen={this.afterOpenModal}
-        onRequestClose={this.closeModal}
-        style={customStyles}
-        contentLabel="Sign out modal">
-        <div className='sign-out-modal'>
-          <h3>Sign Out ?</h3>
-          <hr/>
-          <div className='sign-out-modal'>
-            <button
-              onClick={this.signOut}
-              type="button"
-              className="btn btn-outline-danger sign-out-modal-yes">
+  return (
+    <Modal
+      isOpen={isOpen}
+      style={customStyles}
+      contentLabel="Sign out modal">
+      <div className="sign-out-modal">
+        <h3>Sign Out ?</h3>
+        <hr/>
+        <div className="sign-out-modal">
+          <button
+            onClick={signOut}
+            type="button"
+            className="btn btn-outline-danger sign-out-modal-yes"
+          >
             Yes
-            </button>
-            <button
-              onClick={() => this.props.dispatch(toggleSignOutModal())}
-              type="button"
-              className="btn btn-outline-danger sign-out-modal-no">
+          </button>
+          <button
+            onClick={() => toggleSignOutModal()}
+            type="button"
+            className="btn btn-outline-danger sign-out-modal-no"
+          >
             No
-            </button>
-          </div>
+          </button>
         </div>
-      </Modal>
-    )
-  }
-}
+      </div>
+    </Modal>
+  );
+};
 
 const customStyles = {
   content: {
@@ -55,7 +56,10 @@ const customStyles = {
     bottom: 'auto',
     marginRight: '-50%',
     transform: 'translate(-50%, -50%)'
-  }
-}
+  },
+};
 
-export default connect(null)(SignOutModal)
+export default connect(
+  null,
+  { logInStateChange, toggleSignOutModal },
+)(SignOutModal);


### PR DESCRIPTION
This Pull Requests makes `SignOutModal` a functional component for the lack of need of `state` and later ability to add hooks.
Also a few style improvements were made to add code consistency to the project, like using double quotes for attribute names on HTML elements (which was previously inconsistent), usage of trailing commas and semi colons at the end of each statement.
Object destructuring and mapDispatchToProps shorthand syntax add code clarity.
Related Issue https://github.com/WillzMu/project-zed/issues/41